### PR TITLE
Review obsidian plugin for community publishing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
 				"obsidian": "latest",
 				"rollup": "^4.45.1",
 				"tslib": "2.4.0",
-				"typescript": "4.7.4"
+				"typescript": "^4.7.4"
 			}
 		},
 		"node_modules/@codemirror/language": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 		"obsidian": "latest",
 		"rollup": "^4.45.1",
 		"tslib": "2.4.0",
-		"typescript": "4.7.4"
+		"typescript": "^4.7.4"
 	},
 	"dependencies": {
 		"@codemirror/language": "^6.11.2",


### PR DESCRIPTION
Update `typescript` dependency version to enable successful plugin build.

The `main.js` file was missing, which is required for Obsidian plugin submission. Building the plugin (via `npm install` and `npm run build`) required updating the `typescript` dependency to a compatible version, which was handled by `npm`.

---
<a href="https://cursor.com/background-agent?bcId=bc-8dd10c09-9c4d-4163-b5a0-da0eae5eda07">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8dd10c09-9c4d-4163-b5a0-da0eae5eda07">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>